### PR TITLE
Updated Size label to level in github-actions

### DIFF
--- a/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
@@ -1,7 +1,7 @@
 // Constant variables
-const REQUIRED_LABELS = ['Size', 'role', 'Feature']
-const LABEL_MISSING = ['size: missing', 'role missing', 'Feature Missing']
-const SIZE_EXCEPTIONS = ['good first issue']
+const REQUIRED_LABELS = ['level', 'role', 'Feature']
+const LABEL_MISSING = ['level: missing', 'role missing', 'Feature Missing']
+const LEVEL_EXCEPTIONS = ['good first issue']
 
 // Global variables
 var github
@@ -62,8 +62,8 @@ function checkLabels(labels) {
   REQUIRED_LABELS.forEach((requiredLabel, i) => {
     const regExp = new RegExp(`\\b${requiredLabel}\\b`, 'gi')
     const isLabelPresent = labels.some(label => {
-      // If the label is in the size exceptions array, it also fulfills the size requirements
-      if (SIZE_EXCEPTIONS.includes(label) && requiredLabel === 'Size') {
+      // If the label is in the level exceptions array, it also fulfills the level requirements
+      if (LEVEL_EXCEPTIONS.includes(label) && requiredLabel === 'level') {
         return true
       }
 

--- a/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
+++ b/github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
@@ -2,7 +2,7 @@ var fs = require("fs")
 
 // Constant variables
 const LABELS_OBJ = {
-  'size: missing': 'Size',
+  'level: missing': 'level',
   'role missing': 'Role',
   'Feature Missing': 'Feature'
 }


### PR DESCRIPTION
Fixes #

### Replaced 'Size:' label to 'level:' in

  - github-actions/trigger-issue/add-missing-labels-to-issues/check-labels.js
  - github-actions/trigger-issue/add-missing-labels-to-issues/post-labels-comment.js
 


